### PR TITLE
Umaincall bug fixes

### DIFF
--- a/include/asm/offset.h
+++ b/include/asm/offset.h
@@ -28,22 +28,21 @@
 
 #define OFFSET_SIZE         (8*20)
 
-/* maincall used */ 
-#define OFFSET_UMAINCALL_T1     (8*0)
-#define OFFSET_UMAINCALL_T3     (8*1)
-#define OFFSET_UMAINCALL_RA     (8*2)
-#define OFFSET_UMAINCALL_A0     (8*3)
-#define OFFSET_UMAINCALL_A1     (8*4)
-#define OFFSET_UMAINCALL_A2     (8*5)
-#define OFFSET_UMAINCALL_A3     (8*6)
-#define OFFSET_UMAINCALL_A4     (8*7)
-#define OFFSET_UMAINCALL_A5     (8*8)
-#define OFFSET_UMAINCALL_A6     (8*9)
-#define OFFSET_UMAINCALL_A7     (8*10)
-#define OFFSET_UMAINCALL_SP     (8*11)
+/* maincall used */
+#define OFFSET_UMAINCALL_T0     (8*0)
+#define OFFSET_UMAINCALL_T1     (8*1)
+#define OFFSET_UMAINCALL_T3     (8*2)
+#define OFFSET_UMAINCALL_RA     (8*3)
+#define OFFSET_UMAINCALL_A0     (8*4)
+#define OFFSET_UMAINCALL_A1     (8*5)
+#define OFFSET_UMAINCALL_A2     (8*6)
+#define OFFSET_UMAINCALL_A3     (8*7)
+#define OFFSET_UMAINCALL_A4     (8*8)
+#define OFFSET_UMAINCALL_A5     (8*9)
+#define OFFSET_UMAINCALL_A6     (8*10)
+#define OFFSET_UMAINCALL_A7     (8*11)
+#define OFFSET_UMAINCALL_SP     (8*12)
 
-
-
-#define OFFSET_UMAINCALL        (8*12)
+#define OFFSET_UMAINCALL        (8*13)
 
 #endif

--- a/include/udasics.h
+++ b/include/udasics.h
@@ -47,7 +47,7 @@ void resgister_ufetch_fault_handler(utrap_handler fetch_fault_handler);
 
 
 // DASICS maincall
-uint64_t dasics_umaincall_helper(struct umaincall * regs, ...);
+void dasics_umaincall_helper(struct umaincall * regs, ...);
 
 // source but don't include 
 struct ucontext_trap;

--- a/include/umaincall.h
+++ b/include/umaincall.h
@@ -25,6 +25,7 @@ typedef unsigned long reg_t;
 
 struct umaincall
 {
+    reg_t t0;
     reg_t t1;
     reg_t t3;
     reg_t ra;
@@ -40,18 +41,19 @@ struct umaincall
 };
 
 
-#define OFFSET_UMAINCALL_T1     (8*0)
-#define OFFSET_UMAINCALL_T3     (8*1)
-#define OFFSET_UMAINCALL_RA     (8*2)
-#define OFFSET_UMAINCALL_A0     (8*3)
-#define OFFSET_UMAINCALL_A1     (8*4)
-#define OFFSET_UMAINCALL_A2     (8*5)
-#define OFFSET_UMAINCALL_A3     (8*6)
-#define OFFSET_UMAINCALL_A4     (8*7)
-#define OFFSET_UMAINCALL_A5     (8*8)
-#define OFFSET_UMAINCALL_A6     (8*9)
-#define OFFSET_UMAINCALL_A7     (8*10)
-#define OFFSET_UMAINCALL_SP     (8*11)
+#define OFFSET_UMAINCALL_T0     (8*0)
+#define OFFSET_UMAINCALL_T1     (8*1)
+#define OFFSET_UMAINCALL_T3     (8*2)
+#define OFFSET_UMAINCALL_RA     (8*3)
+#define OFFSET_UMAINCALL_A0     (8*4)
+#define OFFSET_UMAINCALL_A1     (8*5)
+#define OFFSET_UMAINCALL_A2     (8*6)
+#define OFFSET_UMAINCALL_A3     (8*7)
+#define OFFSET_UMAINCALL_A4     (8*8)
+#define OFFSET_UMAINCALL_A5     (8*9)
+#define OFFSET_UMAINCALL_A6     (8*10)
+#define OFFSET_UMAINCALL_A7     (8*11)
+#define OFFSET_UMAINCALL_SP     (8*12)
 
 
 #define OFFSET_UMAINCALL        sizeof(struct umaincall)

--- a/src/maincall/umaincall_entry.S
+++ b/src/maincall/umaincall_entry.S
@@ -5,6 +5,7 @@
 .macro SAVE_MAINCALL
     addi sp, sp,  -OFFSET_UMAINCALL
 
+    sd t0, OFFSET_UMAINCALL_T0(sp)
     sd t1, OFFSET_UMAINCALL_T1(sp)
     sd t3, OFFSET_UMAINCALL_T3(sp)
     sd ra, OFFSET_UMAINCALL_RA(sp)
@@ -18,11 +19,11 @@
     sd a7, OFFSET_UMAINCALL_A7(sp)
     addi t0, sp, OFFSET_UMAINCALL
     sd t0, OFFSET_UMAINCALL_SP(sp)
-    
 .endm
 
 
 .macro RESTORE_MAINCALL
+    ld t0, OFFSET_UMAINCALL_T0(sp)
     ld t1, OFFSET_UMAINCALL_T1(sp)
     ld t3, OFFSET_UMAINCALL_T3(sp)
     ld ra, OFFSET_UMAINCALL_RA(sp)
@@ -34,8 +35,7 @@
     ld a5, OFFSET_UMAINCALL_A5(sp)
     ld a6, OFFSET_UMAINCALL_A6(sp)
     ld a7, OFFSET_UMAINCALL_A7(sp)
-
-    addi sp, sp,  OFFSET_UMAINCALL
+    ld sp, OFFSET_UMAINCALL_SP(sp)
 .endm
 
 

--- a/src/udasics/udasics.c
+++ b/src/udasics/udasics.c
@@ -187,12 +187,12 @@ static int dasics_bound_checker(uint64_t lo, uint64_t hi, int perm)
 }
 
 
-uint64_t dasics_umaincall_helper(struct umaincall * regs, ...)
+void dasics_umaincall_helper(struct umaincall * regs, ...)
 {
     // uint64_t dasics_return_pc = csr_read(0x8b1);            // DasicsReturnPC
     // uint64_t dasics_free_zone_return_pc = csr_read(0x8b2);  // DasicsFreeZoneReturnPC
     // Judge This is a dynamic call
-    if (dasics_dynamic_call(regs)) return 0;
+    if (dasics_dynamic_call(regs)) return;
 
     uint64_t retval = 0;
 
@@ -205,7 +205,7 @@ uint64_t dasics_umaincall_helper(struct umaincall * regs, ...)
     {
         case Umaincall_PRINT: {
             const char *format = va_arg(args, const char *);
-            vprintf(format, args);
+            retval = vprintf(format, args);
         }
         break;
 
@@ -215,12 +215,11 @@ uint64_t dasics_umaincall_helper(struct umaincall * regs, ...)
     }
 
     regs->t1 = regs->ra;
+    regs->a0 = retval;
     // csr_write(0x8b1, dasics_return_pc);             // DasicsReturnPC
     // csr_write(0x8b2, dasics_free_zone_return_pc);   // DasicsFreeZoneReturnPC
 
     va_end(args);
-
-    return retval;
 }
 
 static int dasics_oldest_victim(void) {


### PR DESCRIPTION
1. The original retval of dasics_umaincall_helper will be overwritten by the context swtiching mechanism.
2. Add t0 register to context switching of umaincall, as performed in nested branch.