### PR TITLE
[bug-fix] change a0 to sp before umain_helper

### DIFF
--- a/src/maincall/umaincall_entry.S
+++ b/src/maincall/umaincall_entry.S
@@ -50,8 +50,9 @@ ENTRY(dasics_umaincall)
     // Let's do dasics_dynamic_call first
     call dasics_dynamic_call
     bnez a0, 1f
-    ld   t0, umaincall_helper
-    jalr t0
+    mv   a0, sp
+    ld   t4, umaincall_helper
+    jalr t4
 1:
     RESTORE_MAINCALL
     jr t1


### PR DESCRIPTION
In umaincall_helper, the a0 parameter is a reg pointer and needs to be reset to its original sp value before the call, otherwise dasics_dynamic_call returns