### PR TITLE
fix(trap_entry.S): ecall must not be executed if custom check failed

### DIFF
--- a/src/utrap/trap_entry.S
+++ b/src/utrap/trap_entry.S
@@ -138,8 +138,14 @@ END(_setup_fault)
 # Deal invoke_syscall carefully
 ENTRY(invoke_syscall)
     mv a0, sp
-    call handle_DasicsUEcallFault
+    ld t0, udasics_ecall_fault_handler
+    jalr t0
+    bnez a0, check_failed
     RESTORE_CONTEXT
-    ecall 
+    ecall
     uret
+check_failed:
+    la t0, __dasics_uret
+    jr t0
+    ret
 END(invoke_syscall)

--- a/src/utrap/trap_entry.S
+++ b/src/utrap/trap_entry.S
@@ -147,5 +147,4 @@ ENTRY(invoke_syscall)
 check_failed:
     la t0, __dasics_uret
     jr t0
-    ret
 END(invoke_syscall)


### PR DESCRIPTION
1. Ecall instruction will be executed anyway as the check result is not used.
2. If the user has customized DasicsUEcallFault handler via 'register_uecall_fault_handler', the default handler will still be used.