### PR TITLE
feat(usyscall.h): add assembly macros in usyscall.h, which benefits testing ulib syscalls

### DIFF
--- a/include/usyscall.h
+++ b/include/usyscall.h
@@ -8,6 +8,42 @@ extern "C" {
 #include <syscall.h>
 #include <stdint.h>
 
+#define SYSCALL_ARGS long sysno, long arg1, long arg2, \
+        long arg3, long arg4, long arg5, long arg6
+
+static inline long __attribute__((always_inline)) ulib_syscall(SYSCALL_ARGS) {
+    register long a0 asm("a0") = arg1;
+    register long a1 asm("a1") = arg2;
+    register long a2 asm("a2") = arg3;
+    register long a3 asm("a3") = arg4;
+    register long a4 asm("a4") = arg5;
+    register long a5 asm("a5") = arg6;
+    register long a7 asm("a7") = sysno;
+
+    asm volatile("ecall"                        \
+                 : "+r"(a0)                     \
+                 : "r"(a1), "r"(a2), "r"(a3),   \
+                   "r"(a4), "r"(a5), "r"(a7)    \
+                 : "memory");
+
+    return a0;
+}
+
+#define ULIB_SYSCALL6(sysno, arg1, arg2, arg3, arg4, arg5, arg6) \
+	ulib_syscall(sysno, (long)arg1, (long)arg2, (long)arg3, (long)arg4, (long)arg5, (long)arg6)
+#define ULIB_SYSCALL5(sysno, arg1, arg2, arg3, arg4, arg5) \
+	ULIB_SYSCALL6(sysno, arg1, arg2, arg3, arg4, arg5, 0)
+#define ULIB_SYSCALL4(sysno, arg1, arg2, arg3, arg4) \
+	ULIB_SYSCALL6(sysno, arg1, arg2, arg3, arg4, 0, 0)
+#define ULIB_SYSCALL3(sysno, arg1, arg2, arg3) \
+	ULIB_SYSCALL6(sysno, arg1, arg2, arg3, 0, 0, 0)
+#define ULIB_SYSCALL2(sysno, arg1, arg2) \
+    ULIB_SYSCALL6(sysno, arg1, arg2, 0, 0, 0, 0)
+#define ULIB_SYSCALL1(sysno, arg1) \
+	ULIB_SYSCALL6(sysno, arg1, 0, 0, 0, 0, 0)
+#define ULIB_SYSCALL0(sysno) \
+    ULIB_SYSCALL6(sysno, 0, 0, 0, 0, 0, 0)
+
 typedef int (*ecall_check_handler)(unsigned long, \
                                     unsigned long, \
                                     unsigned long, \

--- a/include/usyscall.h
+++ b/include/usyscall.h
@@ -30,17 +30,17 @@ static inline long __attribute__((always_inline)) ulib_syscall(SYSCALL_ARGS) {
 }
 
 #define ULIB_SYSCALL6(sysno, arg1, arg2, arg3, arg4, arg5, arg6) \
-	ulib_syscall(sysno, (long)arg1, (long)arg2, (long)arg3, (long)arg4, (long)arg5, (long)arg6)
+    ulib_syscall(sysno, (long)arg1, (long)arg2, (long)arg3, (long)arg4, (long)arg5, (long)arg6)
 #define ULIB_SYSCALL5(sysno, arg1, arg2, arg3, arg4, arg5) \
-	ULIB_SYSCALL6(sysno, arg1, arg2, arg3, arg4, arg5, 0)
+    ULIB_SYSCALL6(sysno, arg1, arg2, arg3, arg4, arg5, 0)
 #define ULIB_SYSCALL4(sysno, arg1, arg2, arg3, arg4) \
-	ULIB_SYSCALL6(sysno, arg1, arg2, arg3, arg4, 0, 0)
+    ULIB_SYSCALL6(sysno, arg1, arg2, arg3, arg4, 0, 0)
 #define ULIB_SYSCALL3(sysno, arg1, arg2, arg3) \
-	ULIB_SYSCALL6(sysno, arg1, arg2, arg3, 0, 0, 0)
+    ULIB_SYSCALL6(sysno, arg1, arg2, arg3, 0, 0, 0)
 #define ULIB_SYSCALL2(sysno, arg1, arg2) \
     ULIB_SYSCALL6(sysno, arg1, arg2, 0, 0, 0, 0)
 #define ULIB_SYSCALL1(sysno, arg1) \
-	ULIB_SYSCALL6(sysno, arg1, 0, 0, 0, 0, 0)
+    ULIB_SYSCALL6(sysno, arg1, 0, 0, 0, 0, 0)
 #define ULIB_SYSCALL0(sysno) \
     ULIB_SYSCALL6(sysno, 0, 0, 0, 0, 0, 0)
 


### PR DESCRIPTION
In untrusted functions, directly calling unistd.h functions will fail due to DASICS proctection, leading to difficulties of testing untrusted syscalls. However, we can use assembly instructions to evade this problem as follows:

~~~c
int __attribute__((section(".ulibtext.test_syscall"))) test_syscall() {
    dasics_umaincall(Umaincall_PRINT, "************* ULIB START ***************** \n");  // lib call main

    uint64_t pid = UINT64_MAX;
    pid = ULIB_SYSCALL0(__NR_getpid);  // That's ok (sysno = 172)
    dasics_umaincall(Umaincall_PRINT, "pid = %ld\n", pid);  // That's ok

    ULIB_SYSCALL0(__NR_exit);  // raise DasicsUSyscallAccessFault (sysno = 93)
    dasics_umaincall(Umaincall_UNKNOWN, 0xdeadbeef);  // cancelled by fit_check_maincall

    dasics_umaincall(Umaincall_PRINT, "************* ULIB   END ***************** \n");  // lib call main

    return 0;
}
~~~

The corresponding macros ULIB_SYSCALLX is added in usyscalls.h, and beneficial for testing untrusted syscalls.